### PR TITLE
Add return statement to isSpatialColumn

### DIFF
--- a/lib/spatial.js
+++ b/lib/spatial.js
@@ -124,6 +124,7 @@ const SpatialUtil = {
     if (!definition.dbType) return false
 
     let [ $, dbType, geoType, srid ] = SpatialUtil.spatialTypeRegex.exec(definition.dbType) || [ ]
+    return dbType === 'geometry'
   }
 }
 


### PR DESCRIPTION
This adds a return statement to the `isSpatialColumn` utility function. I'm assuming this is desired functionality but if not just let me know. 
