### PR TITLE
Remove code which transforms stringified array into array

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -329,16 +329,8 @@ const Util = {
    * Cast values to the correct type
    */
   castValues (values) {
-    return _.map(values, value => {
-      if (_.isString(value) && value[0] === '[') {
-        let arr = JSON.parse(value)
-        if (_.isArray(arr)) {
-          return arr
-        }
-      }
-
-      return value
-    })
+    // No special handling currently
+    return values;
   },
 
   castResultRows (rows, schema) {


### PR DESCRIPTION
This fixes https://github.com/waterlinejs/postgresql-adapter/issues/5 based on how node-postgres expects json values to be passed.
