### PR TITLE
Modify wl-sql query to be case insensitive based upon adapter settings

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -180,7 +180,7 @@ const Adapter = {
   },
 
   _query (cxn, query, values) {
-    return cxn.knex.raw(Util.toKnexRawQuery(query), Util.castValues(values))
+    return cxn.knex.raw(Util.toKnexRawQuery(query, Adapter.wlSqlOptions), Util.castValues(values))
       .then((result = { }) => result)
   },
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -320,9 +320,14 @@ const Util = {
   /**
    * Convert a parameterized waterline query into a knex-compatible query string
    */
-  toKnexRawQuery (sql) {
-    return (sql || '').replace(/\$\d+/g, '?')
-      .replace(/LOWER\(("\w+"."\w+")\)/ig, '$1')
+  toKnexRawQuery (sql, wlSqlOptions) {
+    sql = (sql || '').replace(/\$\d+/g, '?')
+    // Ignore wlSqlOptions if not passed
+    if (!wlSqlOptions || wlSqlOptions.wlNext.caseSensitive) {
+      sql = sql.replace(/LOWER\(("\w+"."\w+")\)/ig, '$1')
+    }
+
+    return sql
   },
 
   /**


### PR DESCRIPTION
I found that when setting `wlNext.caseSensitive` to `false` to use waterline-sequel's default case insensitivity, the adapter was still removing the `LOWER()`s in the query generated by waterline-sequel.  Since wl-sql had lower-cased the query parameters, this lead to some bugginess.  This PR ensures that when options for wl-sql are passed to the utility that prepares the query, it takes those options into account.

CC @lynnaloo 
