### PR TITLE
Ensure wlSqlOptions are always used when processing raw query

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -180,7 +180,7 @@ const Adapter = {
   },
 
   _query (cxn, query, values) {
-    return cxn.knex.raw(Util.toKnexRawQuery(query, Adapter.wlSqlOptions), Util.castValues(values))
+    return cxn.knex.raw(Util.toKnexRawQuery(query), Util.castValues(values))
       .then((result = { }) => result)
   },
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -320,10 +320,11 @@ const Util = {
   /**
    * Convert a parameterized waterline query into a knex-compatible query string
    */
-  toKnexRawQuery (sql, wlSqlOptions) {
+  toKnexRawQuery (sql) {
+    const wlSqlOptions = Adapter.wlSqlOptions
+
     sql = (sql || '').replace(/\$\d+/g, '?')
-    // Ignore wlSqlOptions if not passed
-    if (!wlSqlOptions || wlSqlOptions.wlNext.caseSensitive) {
+    if (_.get(wlSqlOptions, 'wlNext.caseSensitive')) {
       sql = sql.replace(/LOWER\(("\w+"."\w+")\)/ig, '$1')
     }
 


### PR DESCRIPTION
Hey @tjwebb – sorry, I think I made an incomplete fix yesterday on #20 .  I was trying to only affect `toKnexRawQuery()` for the one code-path that I understood, and maintain its original behavior in other cases.  Turns out those other cases (i.e. when it's used while building join queries) needed to be adjusted as well.  I've adjusted it so that `toKnexRawQuery()` always takes the adapter's wl-sql options into account.
